### PR TITLE
Migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/terratest/deploy/chart/k8gb/README.md
+++ b/terratest/deploy/chart/k8gb/README.md
@@ -56,7 +56,7 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | coredns.image.tag | string | `"v0.0.8"` | image tag |
 | coredns.isClusterService | bool | `false` | service: refer to https://www.k8gb.io/docs/service_upgrade.html for upgrading CoreDNS service steps |
 | coredns.serviceAccount | object | `{"create":true,"name":"coredns"}` | Creates serviceAccount for coredns |
-| externaldns.image | string | `"k8s.gcr.io/external-dns/external-dns:v0.9.0"` | external-dns image repo:tag |
+| externaldns.image | string | `"registry.k8s.io/external-dns/external-dns:v0.9.0"` | external-dns image repo:tag |
 | externaldns.interval | string | `"20s"` | external-dns sync interval |
 | externaldns.securityContext.fsGroup | int | `65534` | For ExternalDNS to be able to read Kubernetes and AWS token files |
 | externaldns.securityContext.runAsNonRoot | bool | `true` |  |

--- a/terratest/deploy/chart/k8gb/values.yaml
+++ b/terratest/deploy/chart/k8gb/values.yaml
@@ -47,7 +47,7 @@ k8gb:
 
 externaldns:
   # -- external-dns image repo:tag
-  image: k8s.gcr.io/external-dns/external-dns:v0.9.0
+  image: registry.k8s.io/external-dns/external-dns:v0.9.0
   # -- external-dns sync interval
   interval: "20s"
   securityContext:

--- a/terratest/terratest.mk
+++ b/terratest/terratest.mk
@@ -48,11 +48,11 @@ deploy-clusters:
 
 pull-images:
 	@echo -e "\n$(YELLOW)Pulling Images to be imported into clusters$(NC)"
-	docker pull k8s.gcr.io/ingress-nginx/controller:v1.1.1
+	docker pull registry.k8s.io/ingress-nginx/controller:v1.1.1
 	docker pull ghcr.io/stefanprodan/podinfo:5.2.0
 	docker pull absaoss/k8s_crd:v0.0.8
 	docker pull absaoss/external-dns:rfc-ns1
-	docker pull k8s.gcr.io/ingress-nginx/controller:v1.1.1
+	docker pull registry.k8s.io/ingress-nginx/controller:v1.1.1
 	docker pull docker.io/kuritka/k8s_crd:latest-alpha14
 
 prepare-cluster-%:
@@ -72,10 +72,10 @@ deploy-cluster-%:
 
 	@echo -e "\n$(YELLOW)Import Images $(CYAN)$(*)$(NC)"
 	k3d image import ghcr.io/stefanprodan/podinfo:5.2.0 -c $(*)
-	k3d image import k8s.gcr.io/ingress-nginx/controller:v1.1.1 -c $(*)
+	k3d image import registry.k8s.io/ingress-nginx/controller:v1.1.1 -c $(*)
 	k3d image import absaoss/k8s_crd:v0.0.8 -c $(*)
 	k3d image import absaoss/external-dns:rfc-ns1 -c $(*)
-	k3d image import k8s.gcr.io/ingress-nginx/controller:v1.1.1 -c $(*)
+	k3d image import registry.k8s.io/ingress-nginx/controller:v1.1.1 -c $(*)
 	k3d image import kuritka/k8s_crd:latest-alpha14 -c $(*)
 	k3d image import ${REPOSITORY}/${BIN}:${TAG} -c $(*)
 


### PR DESCRIPTION
This PR does the following changes:
- modify all occurrences of k8s.gcr.io to registry.k8s.io.

This is a part of https://github.com/kubernetes/k8s.io/issues/4780.